### PR TITLE
Remove Homebrew's deprecated `:bottle unneeded`

### DIFF
--- a/Formula/exoscale-cli.rb
+++ b/Formula/exoscale-cli.rb
@@ -6,7 +6,6 @@ class ExoscaleCli < Formula
   desc "Manage easily your Exoscale infrastructure from the command-line."
   homepage "https://exoscale.github.io/cli/"
   version "1.45.2"
-  bottle :unneeded
 
   on_macos do
     url "https://github.com/exoscale/cli/releases/download/v1.45.2/exoscale-cli_1.45.2_darwin_all.tar.gz"


### PR DESCRIPTION
Fixes this Homebrew warning:

```shell
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the exoscale/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/exoscale/homebrew-tap/Formula/exoscale-cli.rb:9
```

According to Homebrew/discussions#2311, the call can [just be removed](https://github.com/Homebrew/discussions/discussions/2311#discussioncomment-1507233).